### PR TITLE
Fix setting of non-default IRAF root

### DIFF
--- a/install
+++ b/install
@@ -741,7 +741,7 @@ BINDIRS="$hbin $hlib $fbin $host"
 
 
 # The following file lists are partially system dependent.
-PATHFILES="mkiraf.${extn} libc/iraf.h cl.${extn} ecl.${extn} vocl.${extn} setup.sh setup.csh"
+PATHFILES="mkiraf.${extn} libc/iraf.h cl.${extn} ecl.${extn} vocl.${extn} setup.sh setup.csh libc/libc.h"
 MODEFILES="cl.${extn} fc.${extn} mkiraf.${extn} mkfloat.${extn} mkmlist.${extn} $host/reboot generic.e mkpkg.e rmbin.e rmfiles.e rpp.e rtar.e wtar.e xc.e xpp.e xyacc.e sgidispatch.e $hbin/sgi2*.e irafarch.${extn}"
 LINKFILES="ecl.${extn} cl.${extn} vocl.${extn} mkiraf.${extn} mkmlist.${extn} generic.e mkpkg.e rmbin.e rmfiles.e rtar.e sgidispatch.e wtar.e rpp.e xpp.e xyacc.e xc.e"
 LINKCMDS=(ecl cl vocl mkiraf mkmlist generic mkpkg rmbin rmfiles rtar sgidispatch wtar rpp xpp xyacc xc)


### PR DESCRIPTION
Add `libc/libc.h` to the list of files which need to be patched for a new IRAF root as [recommended by @iraf](https://github.com/iraf/iraf-v216/issues/3#issuecomment-298389713). I  must say that I don't understand @iraf here: Why don't you just commit that instead of having a lengthy discussion? Could you then please merge this PR?
This shall fix #7.

There are however a number of other files that still have `/iraf/iraf`:

* `unix/bin.linux64/f2c.h`
  `unix/bin.linux/f2c.h`
  `unix/bin.macintel/f2c.h`
   Other `f2c.h` (there are 10 of them!!!) don't have this however, even in `unix/bin.*`
   If this `f2c.h` is used ever it will fail.
```
#include "/iraf/iraf/unix/hlib/libc/kproto.h"
#include "/iraf/iraf/unix/hlib/libc/vosproto.h"
```

* `unix/boot/xyacc/dextern.h`
   used in `unix/boot/xyacc/y2.c` as `char *parser = PARSER;`
   as default parser (may be overwritten on cmd line).
  Do we need to patch this as well?
```
#define	PARSER "/iraf/iraf/lib/yaccpar.x"
```

* `unix/boot/spp/xc.c`
   `NEED_GCC_SPECS` is however never defined, so we can ignore this?
```
#ifdef NEED_GCC_SPECS
 ...
arglist[nargs++] = "/iraf/iraf/unix/bin/gcc-specs";
```

* `vendor/x11iraf/ximtool/raster.c`
  `vendor/x11iraf/vximtool/vximtool.c`
   This is x11iraf, which is not the scope in the moment...
```
static char *fb_paths[] = { ... "/iraf/iraf/dev/imtoolrc",
```
