### PR TITLE
Replace absolute symlinks in sys/osb by relative ones

### DIFF
--- a/sys/osb/bytmov.c
+++ b/sys/osb/bytmov.c
@@ -1,1 +1,1 @@
-/iraf/iraf/unix/as/bytmov.c
+../../unix/as/bytmov.c

--- a/sys/osb/d1mach.f
+++ b/sys/osb/d1mach.f
@@ -1,1 +1,1 @@
-/iraf/iraf/unix/hlib/d1mach.f
+../../unix/hlib/d1mach.f

--- a/sys/osb/i1mach.f
+++ b/sys/osb/i1mach.f
@@ -1,1 +1,1 @@
-/iraf/iraf/unix/hlib/i1mach.f
+../../unix/hlib/i1mach.f

--- a/sys/osb/r1mach.f
+++ b/sys/osb/r1mach.f
@@ -1,1 +1,1 @@
-/iraf/iraf/unix/hlib/r1mach.f
+../../unix/hlib/r1mach.f


### PR DESCRIPTION
The link of `bytmov.c` will be resolved by `make <arch>` command which symlinks `unix/as` to the architecture dependent subdir.
This fixes #32.