### PR TITLE
Build vendor libs before starting the NOVOS build

### DIFF
--- a/util/mksysgen
+++ b/util/mksysgen
@@ -45,16 +45,16 @@ cd $iraf/unix					# NOVOS bootstrap
 source hlib/irafuser.sh
 sh -x mkpkg.sh 2>&1 | tee -a spool
 
+cd $iraf/vendor                                 # build vendor libs
+make all 2>&1 | tee -a ../spool.final
+cd ../
+
 cd $iraf/					# build NOVOS
 mkpkg 2>&1 | tee -a spool
 
 cd $iraf/unix					# VOS bootstrap
 source hlib/irafuser.sh
 sh -x mkpkg.sh 2>&1 | tee -a spool
-
-cd $iraf/vendor					# build vendor libs
-make all 2>&1 | tee -a ../spool.final
-cd ../
 
 cd $iraf/					# build core system
 mkpkg 2>&1 | tee -a spool


### PR DESCRIPTION
These libs (especially `libVO.a`) are required to build some of the libs, even in NOVOS mode.

Together with #38 (third commit there), this fixes #26.
