### PR TITLE
Call the PLT for __sigsetjmp instead of calling directly

### DIFF
--- a/unix/as.linux64/zsvjmp.s
+++ b/unix/as.linux64/zsvjmp.s
@@ -18,11 +18,9 @@
 # of one longword containing the address of the STATUS variable, followed
 # by the "jmp_buf" used by setjmp/longjmp.
 #
-# This file contains the FreeBSD (x86) version of ZSVJMP.
-# Modified to remove leading underscore for ELF (Jan99).
  
-        #.globl	_zsvjmp_
         .globl	zsvjmp_
+	.type   zsvjmp_, @function
 
 	# The following has nothing to do with ZSVJMP, and is included here
 	# only because this assembler module is loaded with every process.
@@ -33,10 +31,8 @@
 	# advantage is that references to NULL pointers are likely to cause a
 	# memory violation.
 
-	#.globl	mem_
-	#mem_	=	0
-	.globl	_mem_
-	_mem_	=	0
+	.globl  _mem_
+	_mem_   =       0
 
 zsvjmp_:
 	# %rsi ... &status  %rdi ... &jumpbuf
@@ -44,5 +40,6 @@ zsvjmp_:
 	movl    $0, (%rsi)      # zero the value of status
 	addq    $8, %rdi        # change point to &jmpbuf[1]
 	movl    $0, %esi        # change arg2 to zero
-	jmp     __sigsetjmp     # let sigsetjmp do the rest
+	jmp     __sigsetjmp@PLT # let sigsetjmp do the rest
 
+	.section        .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Otherwise, one may get a linker error on modern systems (Debian Stretch, Ubuntu 17.04 etc.).
To reproduce this error, just create an empty main and try to link:
```
$ echo 'int main(void) {}' > main.c
$ gcc main.c unix/as.linux64/zsvjmp.s -o main
/usr/bin/ld: /tmp/cceS36ym.o: relocation R_X86_64_PC32 against symbol `__sigsetjmp@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```
I took the opportunity to add a few metadata (`.section`, `.type`) to the file.