### PR TITLE
Remove curl/types.h includes

### DIFF
--- a/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/lib/curl_transport/curlmulti.c
+++ b/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/lib/curl_transport/curlmulti.c
@@ -17,9 +17,6 @@
 #endif
 
 #include <curl/curl.h>
-#if(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7)
-#include <curl/types.h>
-#endif
 #include <curl/easy.h>
 #include <curl/multi.h>
 

--- a/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/lib/curl_transport/curltransaction.c
+++ b/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/lib/curl_transport/curltransaction.c
@@ -15,9 +15,6 @@
 #include "version.h"
 
 #include <curl/curl.h>
-#if(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7)
-#include <curl/types.h>
-#endif
 #include <curl/easy.h>
 
 #include "curlversion.h"

--- a/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/lib/curl_transport/xmlrpc_curl_transport.c
+++ b/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/lib/curl_transport/xmlrpc_curl_transport.c
@@ -83,9 +83,6 @@
 #include "xmlrpc-c/time_int.h"
 
 #include <curl/curl.h>
-#if(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7)
-#include <curl/types.h>
-#endif
 #include <curl/easy.h>
 #include <curl/multi.h>
 

--- a/vendor/voclient/libvotable/examples/votget.c
+++ b/vendor/voclient/libvotable/examples/votget.c
@@ -62,7 +62,6 @@ main (int argc, char **argv)
 #include <pthread.h>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 #include "votParse.h"

--- a/vendor/voclient/libvotable/votParse.c
+++ b/vendor/voclient/libvotable/votParse.c
@@ -19,7 +19,6 @@
 #include <sys/stat.h>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 #include "votParseP.h"

--- a/vendor/voclient/voapps/lib/voInv.c
+++ b/vendor/voclient/voapps/lib/voInv.c
@@ -14,7 +14,6 @@
 
 #ifdef VO_INVENTORY
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 #include "VOClient.h"
 #include "voAppsP.h"

--- a/vendor/voclient/voapps/lib/voUtil.c
+++ b/vendor/voclient/voapps/lib/voUtil.c
@@ -15,7 +15,6 @@
 #include <time.h>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 #include "VOClient.h"

--- a/vendor/voclient/voapps/lib/vosUtil.c
+++ b/vendor/voclient/voapps/lib/vosUtil.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 

--- a/vendor/voclient/voapps/votget.c
+++ b/vendor/voclient/voapps/votget.c
@@ -56,7 +56,6 @@
 #include <pthread.h>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 #include "samp.h"


### PR DESCRIPTION
`curl/types.h` is deprecated since a loooong time. And it is removed since 6 years. Therefore, the code does not build anymore on MacOSX which ships with a more modern version of curl (#49). 
Even with the version that is included in IRAF (7.20.1, 7 years old) `curl/types.h` is not required to be included. So we can just remove it.

This fixes #49.

It is BTW unclear why IRAF uses curl externally on MacOS but ships the own version on Linux. curl is available as a binary package on any Linux version; there is absolutely no need to provide a convenience copy here.