### PR TITLE
Reset the MSB in the result of ADDR_TO_LOC

### DIFF
--- a/unix/hlib/libc/kernel.h
+++ b/unix/hlib/libc/kernel.h
@@ -47,8 +47,11 @@
 /* ZLOCVA style pointer to address conversions.  These macros are used to
  * convert host pointer addresses (in bytes) to/from iraf pointer values
  * in units of XCHAR.
+ *
+ * The address LOC needs to be not negative, so a possibly remaining
+ * most significant bit is masked out.
  */
-#define	ADDR_TO_LOC(addr) 	(((XINT)((XCHAR *)(addr)))>>(sizeof(XCHAR)-1))
+#define	ADDR_TO_LOC(addr) 	((((XINT)((XCHAR *)(addr)))>>(sizeof(XCHAR)-1)) & ~(1 << (8*sizeof(XINT)-1)))
 #define	LOC_TO_ADDR(loc,type)   ((type *)((XCHAR *)((loc)<<(sizeof(XCHAR)-1))))
 
 


### PR DESCRIPTION
This is needed since LOC is later checked to be not negative, but the result of right-shifting the original address may result in a negative value.

Since we left-shift to get back the address, this bit is lost anyway, as long as `XCHAR` is `short` (hardcoded in many places).