### PR TITLE
Fix computation of offset in memory allocation at 32 bit

### DIFF
--- a/sys/nmemio/msvfwa.x
+++ b/sys/nmemio/msvfwa.x
@@ -35,7 +35,7 @@ begin
 
 	} else if (nbits == 32) { 
 
-	    if (sizeof(dtype) < sz_align)
+	    if (sizeof(dtype) <= SZ_INT)
 	        offset = (nelem / (SZ_INT / sizeof(dtype))) + 1
 	    else
 	        offset = (nelem * sizeof (dtype)) / SZB_CHAR


### PR DESCRIPTION
If the data size was between `SZ_INT` and `SZ_MEMALIGN` (2<4<8), IRAF crashed on 32 bit because of an integer division by zero. This patch fixes this.

Closes #63 

After this (and all the PRs before), the "linux" branch passes [initial tests](https://github.com/olebole/iraf-v216/blob/39d5372cf98980da3c2d6e6a6dc387b04c8b0a7a/test/testproc.md).