### PR TITLE
Add libbev.a link

### DIFF
--- a/lib/libbev.a
+++ b/lib/libbev.a
@@ -1,0 +1,1 @@
+../bin/libbev.a


### PR DESCRIPTION
Without this link, the library `libbev.a` is installed in the `lib` subdir. However, like the other libraries, it is system dependent and therefore should go to `bin`. This link ensures that.