### PR TITLE
Fix linenumber generation with xpp -x (rpp and spp)

### DIFF
--- a/unix/boot/spp/rpp/rppfor/ngetch.f
+++ b/unix/boot/spp/rpp/rppfor/ngetch.f
@@ -81,6 +81,7 @@
       linect (level) = n - 1
 23006 continue
 23004 continue
+      if (.not.(linect (level) .gt. 0))goto23003
       linect (level) = linect (level) + 1
 23003 continue
       goto 23001

--- a/unix/boot/spp/rpp/rppfor/outdon.f
+++ b/unix/boot/spp/rpp/rppfor/outdon.f
@@ -67,7 +67,8 @@
       data sline0(1)/35/,sline0(2)/108/,sline0(3)/105/,sline0(4)/110/,sl
      *ine0(5)/101/,sline0(6)/32/,sline0(7)/-2/
       if (.not.(dbgout .eq. 1))goto 23000
-      if (.not.(body .eq. 1 .or. dbglev .ne. level))goto 23002
+      if (.not.((body .eq. 1 .or. dbglev .ne. level)
+     * .and. linect (level) .gt. 0))goto 23002
       op = 1
       ip=1
 23004 if (.not.(sline0(ip) .ne. -2))goto 23006

--- a/unix/boot/spp/rpp/rpprat/ngetch.r
+++ b/unix/boot/spp/rpp/rpprat/ngetch.r
@@ -23,7 +23,9 @@
 	       linect (level) = n - 1
 	       }
 	    }
-	 linect (level) = linect (level) + 1
+	    if (linect (level) > 0) {
+	       linect (level) = linect (level) + 1
+	    }
 	 }
    else {
       c = buf (bp)

--- a/unix/boot/spp/rpp/rpprat/outdon.r
+++ b/unix/boot/spp/rpp/rpprat/outdon.r
@@ -13,7 +13,7 @@
 
     # If dbgout is enabled output the "#line" statement.
     if (dbgout == YES) {
-	if (body == YES | dbglev != level) {
+	if ((body == YES | dbglev != level) & linect (level) > 0) {
 	    op = 1
 	    for (ip=1;  s_line(ip) != EOS;  ip=ip+1) {
 		obuf(op) = s_line(ip)

--- a/unix/boot/spp/xpp/xppcode.c
+++ b/unix/boot/spp/xpp/xppcode.c
@@ -822,6 +822,7 @@ skip_helpblock (void)
 	    if (istkptr == 0)
 	        linenum[istkptr]++;
         }
+	linenum[istkptr]++;
 }
 
 
@@ -888,7 +889,6 @@ parse_task_statement (void)
 		if ((ch = nextch()) != '\n')
 		    unput (ch);
 	    } else if (ch == '\n') {
-		linenum[istkptr]++;
 		ntasks++;			/* end of task statement */	
 		break;
 	    } else
@@ -1153,7 +1153,6 @@ begin_code (void)
 	setcontext (BODY);
 	d_runtime (text);  outstr (text);
 	outstr ("begin\n");
-	linenum[istkptr]++;
 
 	/* Initialization. */
 	nbrace = 0;

--- a/unix/hlib/irafuser.sh
+++ b/unix/hlib/irafuser.sh
@@ -69,7 +69,7 @@ case "$MACH" in
 
   "linux64")
     export HSI_CF="-g -DLINUX -DREDHAT -DPOSIX -DSYSV -DLINUX64 -DMACH64 -Wall -m64"
-    export HSI_XF="-g -Inolibc -w -/m64 -/Wunused"
+    export HSI_XF="-x -Inolibc -w -/m64 -/Wunused"
     export HSI_FF="-g -m64 -DBLD_KERNEL"
     export HSI_LF="-m64 "
     export HSI_F77LIBS=""


### PR DESCRIPTION
Currently, the line number calculation of xc is wrong:

File `hello.x` (line numbers added):
```
1   # HELLO -- Sample program introducing SPP.
2   task hello = t_hello_world
3   procedure t_hello_world ()
4   begin
5       call printf ("Hello,world!\n")
6   end
```

Source code line 5 ends up marked as line 7 in the Fortran file:

```
$ xc -x -f hello.x
   sys_runtask:
   t_hello_world:
$ tail -22 hello.f|head -11
      subroutine thelld ()
      integer*2 st0001(14)
      save
      integer iyy
      data (st0001(iyy),iyy= 1, 8) / 72,101,108,108,111, 44,119,111/
      data (st0001(iyy),iyy= 9,14) /114,108,100, 33, 10, 0/
#line 7 "hello.x"
         call xprinf(st0001)
100      call zzepro
         return
      end
```

First, [when `begin` is parsed](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/unix/boot/spp/xpp/xpp.l#L120), the end of line `\n` is not eaten up. In fact, there may be code following after `begin` on the same line; this is placed after xpp in the line after `begin`. If nothing follows the `begin` statement on the same line, an empty line is added. This means, that `linenum` must __not__ increase here; it is increased [when the `\n` of this line is found](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/unix/boot/spp/xpp/xpp.l#L203).

Similar argument for [parsing a `task` line](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/unix/boot/spp/xpp/xpp.l#L107); `linenum` must __not__ increase here as well.

When parsing `.help` ... `.endhelp` however, one `linenum` increase was missing, which is added now.

Another problem is that the resulting intermediate file (output of spp; input for rpp) may contain content from include files, f.e. `lib/sysruk.x`. The line number protocol between spp and rpp does not allow to specify filenames, and spp suppresses the line number output of include files. However, rpp then interprets these lines as coming from the original file name and this way assigns wrong line numbers. Since files are included (explicitly or implicitly) in the beginning of the source file, this is pragmatically solved by supressing the output of line numbers before an explicit line number has been set by spp.

This (re-) enables the possibility to directly debug SPP code (note that the flag to enable debugging in xc is `-x`, not `-g`):
```
$ xc -x hello.x
   sys_runtask:
   t_hello_world:
$ gdb ./hello.e 
GNU gdb (Debian 7.12-6) 7.12.0.20161007-git
[...]
Reading symbols from ./hello.e...done.
(gdb) b thelld_ 
Breakpoint 1 at 0x38e7: file hello.x, line 5.
(gdb) r
Starting program: ./hello.e 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
> hello

Breakpoint 1, thelld_ () at hello.x:5
5	    call printf ("Hello,world!\n")
(gdb) n
Hello,world!
6	end
(gdb)
```
Connected to this, the wrong debug flag given in `irafuser.sh` is corrected as well.
I also added a test for the proper line number generation ad #36.