### PR TITLE
Specify explicit format for fprintf()

### DIFF
--- a/sys/memdbg/memlog.c
+++ b/sys/memdbg/memlog.c
@@ -133,7 +133,7 @@ char	*message;
 	    "------", number++, "------");
 
 	/* Output message. */
-	fprintf (fp, message);
+	fprintf (fp, "%s", message);
 	fprintf (fp, "\n");
 
 	fflush (fp);


### PR DESCRIPTION
This changes
```
fprintf (fp, message);
```
to
```
fprintf (fp, "%s", message);
```
The second argument in `fprintf()` needs to be a format, not the (random) string that is actually filled in. Otherwise, the behaviour is unexpected/undefined when the string contains a percent sign.
