### PR TITLE
Add the required credits for the IRAF64 project.

### DIFF
--- a/local/LICENSES/CREDITS_IRAF64
+++ b/local/LICENSES/CREDITS_IRAF64
@@ -1,0 +1,19 @@
+The IRAF64 Project - CREDITS
+
+Project Director/Developer:
+    Chisato Yamauchi
+
+Project Tester:
+    Brian Crook
+    Keith Rosema
+    Sergio Pascual
+    Yasushi Nakajima
+
+Special Thanks:
+    Hajime Baba
+    Shoichi Tamuki
+    Yoshifusa Ita
+    Mike Fitzpatrick
+    Nelson Zarate
+    Phil Hodge
+

--- a/local/LICENSES/LICENCE_IRAF64
+++ b/local/LICENSES/LICENCE_IRAF64
@@ -1,0 +1,9 @@
+See COPYRIGHTS file for original IRAF.
+
+Do not remove CREDITS_IRAF64 and LICENCE_IRAF64 from IRAF package.
+
+Please display following message when starting IRAF shells;
+
+  This product includes results achieved by the IRAF64 project in 2006-
+  2009 directed by Chisato Yamauchi (C-SODA/ISAS/JAXA).
+

--- a/sys/osb/i32to64.c
+++ b/sys/osb/i32to64.c
@@ -1,3 +1,6 @@
+/* Copyright 2006-2009 Chisato Yamauchi (C-SODA/ISAS/JAXA)
+ */
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/osb/i64to32.c
+++ b/sys/osb/i64to32.c
@@ -1,3 +1,6 @@
+/* Copyright 2006-2009 Chisato Yamauchi (C-SODA/ISAS/JAXA)
+ */
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/unix/hlib/motd
+++ b/unix/hlib/motd
@@ -1,7 +1,8 @@
-
    NOAO/IRAF PC-IRAF Revision 2.16.1 EXPORT Mon Oct 14 21:40:13 MST 2013
       This is the EXPORT version of IRAF V2.16 supporting PC systems.
 
+  This product includes results achieved by the IRAF64 project in 2006-
+  2009 directed by Chisato Yamauchi (C-SODA/ISAS/JAXA).
 
   Welcome to IRAF.  To list the available commands, type ? or ??.  To get
   detailed information about a command, type `help <command>'.  To run  a
@@ -10,5 +11,4 @@
   what is new in the version of the system you are using.  
 
   Visit http://iraf.net if you have questions or to report problems.
-
 


### PR DESCRIPTION
The IRAF64 project contributed a number of bugfixes and some code to IRAF, specifically the files `sys/osb/i32to64.c` and `sys/osb/i64to32.c`.

As asked by @cyamauch, this patch acknowledges this by obeying the license conditions of IRAF64, and adding a copyright statement to the two mentioned files.

This closes #92.